### PR TITLE
chore: release next

### DIFF
--- a/apps/crypto-cli/docs/changelog.md
+++ b/apps/crypto-cli/docs/changelog.md
@@ -1,5 +1,13 @@
 # @twin.org/crypto-cli - Changelog
 
+## 1.0.0 (2025-03-25)
+
+
+### Features
+
+* add version type ([ae50cd9](https://github.com/twinfoundation/framework/commit/ae50cd99d342ed8eeb55290a52e9fed80a2af99e))
+* remove version type ([553aa55](https://github.com/twinfoundation/framework/commit/553aa55bd79b8f930155035e522af2b0f6e3d0c8))
+
 ## 0.0.1-next.49
 
 - Initial Release

--- a/apps/crypto-cli/package.json
+++ b/apps/crypto-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/crypto-cli",
-	"version": "0.0.1-next.49",
+	"version": "1.0.0",
 	"description": "A command line interface for interacting with the crypto tools",
 	"repository": {
 		"type": "git",

--- a/apps/crypto-cli/src/version.ts
+++ b/apps/crypto-cli/src/version.ts
@@ -1,3 +1,3 @@
 // Copyright 2024 IOTA Stiftung.
 // SPDX-License-Identifier: Apache-2.0.
-export const VERSION = "0.0.1-next.49"; // x-release-please-version
+export const VERSION = "1.0.0"; // x-release-please-version

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
 		},
 		"apps/crypto-cli": {
 			"name": "@twin.org/crypto-cli",
-			"version": "0.0.1-next.49",
+			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/cli-core": "0.0.1-next.49",

--- a/release/release-please-manifest.prerelease.json
+++ b/release/release-please-manifest.prerelease.json
@@ -8,5 +8,6 @@
 	"packages/modules": "0.0.1-next.49",
 	"packages/qr": "0.0.1-next.49",
 	"packages/web": "0.0.1-next.49",
-	"packages/crypto-cli": "0.0.1-next.49"
+	"packages/crypto-cli": "0.0.1-next.49",
+	"apps/crypto-cli": "1.0.0"
 }


### PR DESCRIPTION
chore: :robot: prerelease release prepared
---


<details><summary>crypto-cli: 1.0.0</summary>

## 1.0.0 (2025-03-25)


### Features

* add version type ([ae50cd9](https://github.com/twinfoundation/framework/commit/ae50cd99d342ed8eeb55290a52e9fed80a2af99e))
* remove version type ([553aa55](https://github.com/twinfoundation/framework/commit/553aa55bd79b8f930155035e522af2b0f6e3d0c8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).