### PR TITLE
chore: release next

### DIFF
--- a/apps/crypto-cli/docs/changelog.md
+++ b/apps/crypto-cli/docs/changelog.md
@@ -1,5 +1,22 @@
 # @twin.org/crypto-cli - Changelog
 
+## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/crypto-cli-v0.0.1-next.49...crypto-cli-v0.0.1-next.50) (2025-03-25)
+
+
+### Features
+
+* add version type ([ae50cd9](https://github.com/twinfoundation/framework/commit/ae50cd99d342ed8eeb55290a52e9fed80a2af99e))
+* remove version type ([553aa55](https://github.com/twinfoundation/framework/commit/553aa55bd79b8f930155035e522af2b0f6e3d0c8))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/cli-core bumped from 0.0.1-next.49 to 0.0.1-next.50
+    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
+    * @twin.org/crypto bumped from 0.0.1-next.49 to 0.0.1-next.50
+
 ## 0.0.1-next.49
 
 - Initial Release

--- a/apps/crypto-cli/package.json
+++ b/apps/crypto-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/crypto-cli",
-	"version": "0.0.1-next.49",
+	"version": "0.0.1-next.50",
 	"description": "A command line interface for interacting with the crypto tools",
 	"repository": {
 		"type": "git",
@@ -31,9 +31,9 @@
 		"prepare": "ts-patch install -s"
 	},
 	"dependencies": {
-		"@twin.org/cli-core": "0.0.1-next.49",
-		"@twin.org/core": "0.0.1-next.49",
-		"@twin.org/crypto": "0.0.1-next.49",
+		"@twin.org/cli-core": "0.0.1-next.50",
+		"@twin.org/core": "0.0.1-next.50",
+		"@twin.org/crypto": "0.0.1-next.50",
 		"@twin.org/nameof": "next",
 		"commander": "13.1.0"
 	},

--- a/apps/crypto-cli/src/version.ts
+++ b/apps/crypto-cli/src/version.ts
@@ -1,3 +1,3 @@
 // Copyright 2024 IOTA Stiftung.
 // SPDX-License-Identifier: Apache-2.0.
-export const VERSION = "0.0.1-next.49"; // x-release-please-version
+export const VERSION = "0.0.1-next.50"; // x-release-please-version

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,12 +46,12 @@
 		},
 		"apps/crypto-cli": {
 			"name": "@twin.org/crypto-cli",
-			"version": "0.0.1-next.49",
+			"version": "0.0.1-next.50",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/cli-core": "0.0.1-next.49",
-				"@twin.org/core": "0.0.1-next.49",
-				"@twin.org/crypto": "0.0.1-next.49",
+				"@twin.org/cli-core": "0.0.1-next.50",
+				"@twin.org/core": "0.0.1-next.50",
+				"@twin.org/crypto": "0.0.1-next.50",
 				"@twin.org/nameof": "next",
 				"commander": "13.1.0"
 			},
@@ -12081,11 +12081,11 @@
 		},
 		"packages/cli-core": {
 			"name": "@twin.org/cli-core",
-			"version": "0.0.1-next.49",
+			"version": "0.0.1-next.50",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.49",
-				"@twin.org/crypto": "0.0.1-next.49",
+				"@twin.org/core": "0.0.1-next.50",
+				"@twin.org/crypto": "0.0.1-next.50",
 				"@twin.org/nameof": "next",
 				"chalk": "5.4.1",
 				"commander": "13.1.0",
@@ -12112,7 +12112,7 @@
 		},
 		"packages/core": {
 			"name": "@twin.org/core",
-			"version": "0.0.1-next.49",
+			"version": "0.0.1-next.50",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/nameof": "next",
@@ -12139,7 +12139,7 @@
 		},
 		"packages/crypto": {
 			"name": "@twin.org/crypto",
-			"version": "0.0.1-next.49",
+			"version": "0.0.1-next.50",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/ciphers": "1.2.1",
@@ -12148,7 +12148,7 @@
 				"@scure/base": "1.2.4",
 				"@scure/bip32": "1.6.2",
 				"@scure/bip39": "1.5.4",
-				"@twin.org/core": "0.0.1-next.49",
+				"@twin.org/core": "0.0.1-next.50",
 				"@twin.org/nameof": "next",
 				"micro-key-producer": "0.7.5"
 			},
@@ -12172,10 +12172,10 @@
 		},
 		"packages/entity": {
 			"name": "@twin.org/entity",
-			"version": "0.0.1-next.49",
+			"version": "0.0.1-next.50",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.49",
+				"@twin.org/core": "0.0.1-next.50",
 				"@twin.org/nameof": "next",
 				"reflect-metadata": "0.2.2"
 			},
@@ -12199,10 +12199,10 @@
 		},
 		"packages/image": {
 			"name": "@twin.org/image",
-			"version": "0.0.1-next.49",
+			"version": "0.0.1-next.50",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.49",
+				"@twin.org/core": "0.0.1-next.50",
 				"@twin.org/nameof": "next"
 			},
 			"devDependencies": {
@@ -12225,10 +12225,10 @@
 		},
 		"packages/modules": {
 			"name": "@twin.org/modules",
-			"version": "0.0.1-next.49",
+			"version": "0.0.1-next.50",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "next",
+				"@twin.org/core": "0.0.1-next.50",
 				"@twin.org/nameof": "next"
 			},
 			"devDependencies": {
@@ -12266,11 +12266,11 @@
 		},
 		"packages/qr": {
 			"name": "@twin.org/qr",
-			"version": "0.0.1-next.49",
+			"version": "0.0.1-next.50",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.49",
-				"@twin.org/image": "0.0.1-next.49",
+				"@twin.org/core": "0.0.1-next.50",
+				"@twin.org/image": "0.0.1-next.50",
 				"@twin.org/nameof": "next"
 			},
 			"devDependencies": {
@@ -12293,11 +12293,11 @@
 		},
 		"packages/web": {
 			"name": "@twin.org/web",
-			"version": "0.0.1-next.49",
+			"version": "0.0.1-next.50",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.49",
-				"@twin.org/crypto": "0.0.1-next.49",
+				"@twin.org/core": "0.0.1-next.50",
+				"@twin.org/crypto": "0.0.1-next.50",
 				"@twin.org/nameof": "next",
 				"jose": "6.0.8"
 			},

--- a/packages/cli-core/docs/changelog.md
+++ b/packages/cli-core/docs/changelog.md
@@ -1,5 +1,20 @@
 # @twin.org/cli-core - Changelog
 
+## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/cli-core-v0.0.1-next.49...cli-core-v0.0.1-next.50) (2025-03-25)
+
+
+### Miscellaneous Chores
+
+* **cli-core:** Synchronize repo versions
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
+    * @twin.org/crypto bumped from 0.0.1-next.49 to 0.0.1-next.50
+
 ## 0.0.1-next.49
 
 - Initial Release

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/cli-core",
-	"version": "0.0.1-next.49",
+	"version": "0.0.1-next.50",
 	"description": "Core classes for building a CLI",
 	"repository": {
 		"type": "git",
@@ -31,8 +31,8 @@
 		"prepare": "ts-patch install -s"
 	},
 	"dependencies": {
-		"@twin.org/core": "0.0.1-next.49",
-		"@twin.org/crypto": "0.0.1-next.49",
+		"@twin.org/core": "0.0.1-next.50",
+		"@twin.org/crypto": "0.0.1-next.50",
 		"@twin.org/nameof": "next",
 		"chalk": "5.4.1",
 		"commander": "13.1.0",

--- a/packages/core/docs/changelog.md
+++ b/packages/core/docs/changelog.md
@@ -1,5 +1,12 @@
 # @twin.org/core - Changelog
 
+## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/core-v0.0.1-next.49...core-v0.0.1-next.50) (2025-03-25)
+
+
+### Miscellaneous Chores
+
+* **core:** Synchronize repo versions
+
 ## 0.0.1-next.49
 
 - Initial Release

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/core",
-	"version": "0.0.1-next.49",
+	"version": "0.0.1-next.50",
 	"description": "Helper methods/classes for data type checking/validation/guarding/error handling",
 	"repository": {
 		"type": "git",

--- a/packages/crypto/docs/changelog.md
+++ b/packages/crypto/docs/changelog.md
@@ -1,5 +1,19 @@
 # @twin.org/crypto - Changelog
 
+## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/crypto-v0.0.1-next.49...crypto-v0.0.1-next.50) (2025-03-25)
+
+
+### Miscellaneous Chores
+
+* **crypto:** Synchronize repo versions
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
+
 ## 0.0.1-next.49
 
 - Added: Bip44

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/crypto",
-	"version": "0.0.1-next.49",
+	"version": "0.0.1-next.50",
 	"description": "Contains helper methods and classes which implement cryptographic functions",
 	"repository": {
 		"type": "git",
@@ -30,7 +30,7 @@
 		"prepare": "ts-patch install -s"
 	},
 	"dependencies": {
-		"@twin.org/core": "0.0.1-next.49",
+		"@twin.org/core": "0.0.1-next.50",
 		"@twin.org/nameof": "next",
 		"@noble/ciphers": "1.2.1",
 		"@noble/curves": "1.8.1",

--- a/packages/entity/docs/changelog.md
+++ b/packages/entity/docs/changelog.md
@@ -1,5 +1,19 @@
 # @twin.org/entity - Changelog
 
+## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/entity-v0.0.1-next.49...entity-v0.0.1-next.50) (2025-03-25)
+
+
+### Miscellaneous Chores
+
+* **entity:** Synchronize repo versions
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
+
 ## 0.0.1-next.49
 
 - Initial Release

--- a/packages/entity/package.json
+++ b/packages/entity/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/entity",
-	"version": "0.0.1-next.49",
+	"version": "0.0.1-next.50",
 	"description": "Helpers for defining and working with entities",
 	"repository": {
 		"type": "git",
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"@twin.org/nameof": "next",
-		"@twin.org/core": "0.0.1-next.49",
+		"@twin.org/core": "0.0.1-next.50",
 		"reflect-metadata": "0.2.2"
 	},
 	"devDependencies": {

--- a/packages/image/docs/changelog.md
+++ b/packages/image/docs/changelog.md
@@ -1,5 +1,19 @@
 # @twin.org/image - Changelog
 
+## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/image-v0.0.1-next.49...image-v0.0.1-next.50) (2025-03-25)
+
+
+### Miscellaneous Chores
+
+* **image:** Synchronize repo versions
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
+
 ## 0.0.1-next.49
 
 - Initial Release

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/image",
-	"version": "0.0.1-next.49",
+	"version": "0.0.1-next.50",
 	"description": "Classes for image manipulation",
 	"repository": {
 		"type": "git",
@@ -30,7 +30,7 @@
 		"prepare": "ts-patch install -s"
 	},
 	"dependencies": {
-		"@twin.org/core": "0.0.1-next.49",
+		"@twin.org/core": "0.0.1-next.50",
 		"@twin.org/nameof": "next"
 	},
 	"devDependencies": {

--- a/packages/modules/docs/changelog.md
+++ b/packages/modules/docs/changelog.md
@@ -1,5 +1,19 @@
 # @twin.org/modules - Changelog
 
+## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/modules-v0.0.1-next.49...modules-v0.0.1-next.50) (2025-03-25)
+
+
+### Miscellaneous Chores
+
+* **modules:** Synchronize repo versions
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/core bumped from next to 0.0.1-next.50
+
 ## 0.0.1-next.49
 
 - Initial Release

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/modules",
-	"version": "0.0.1-next.49",
+	"version": "0.0.1-next.50",
 	"description": "Helper classes for loading and executing from modules",
 	"repository": {
 		"type": "git",
@@ -30,7 +30,7 @@
 		"prepare": "ts-patch install -s"
 	},
 	"dependencies": {
-		"@twin.org/core": "next",
+		"@twin.org/core": "0.0.1-next.50",
 		"@twin.org/nameof": "next"
 	},
 	"devDependencies": {

--- a/packages/qr/docs/changelog.md
+++ b/packages/qr/docs/changelog.md
@@ -1,5 +1,20 @@
 # @twin.org/qr - Changelog
 
+## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/qr-v0.0.1-next.49...qr-v0.0.1-next.50) (2025-03-25)
+
+
+### Miscellaneous Chores
+
+* **qr:** Synchronize repo versions
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
+    * @twin.org/image bumped from 0.0.1-next.49 to 0.0.1-next.50
+
 ## 0.0.1-next.49
 
 - Initial Release

--- a/packages/qr/package.json
+++ b/packages/qr/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/qr",
-	"version": "0.0.1-next.49",
+	"version": "0.0.1-next.50",
 	"description": "Package for creating QR codes",
 	"repository": {
 		"type": "git",
@@ -30,8 +30,8 @@
 		"prepare": "ts-patch install -s"
 	},
 	"dependencies": {
-		"@twin.org/core": "0.0.1-next.49",
-		"@twin.org/image": "0.0.1-next.49",
+		"@twin.org/core": "0.0.1-next.50",
+		"@twin.org/image": "0.0.1-next.50",
 		"@twin.org/nameof": "next"
 	},
 	"devDependencies": {

--- a/packages/web/docs/changelog.md
+++ b/packages/web/docs/changelog.md
@@ -1,5 +1,20 @@
 # @twin.org/web - Changelog
 
+## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/web-v0.0.1-next.49...web-v0.0.1-next.50) (2025-03-25)
+
+
+### Miscellaneous Chores
+
+* **web:** Synchronize repo versions
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
+    * @twin.org/crypto bumped from 0.0.1-next.49 to 0.0.1-next.50
+
 ## 0.0.1-next.49
 
 - Initial Release

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@twin.org/web",
-	"version": "0.0.1-next.49",
+	"version": "0.0.1-next.50",
 	"description": "Contains classes for use with web operations",
 	"repository": {
 		"type": "git",
@@ -30,8 +30,8 @@
 		"prepare": "ts-patch install -s"
 	},
 	"dependencies": {
-		"@twin.org/core": "0.0.1-next.49",
-		"@twin.org/crypto": "0.0.1-next.49",
+		"@twin.org/core": "0.0.1-next.50",
+		"@twin.org/crypto": "0.0.1-next.50",
 		"@twin.org/nameof": "next",
 		"jose": "6.0.8"
 	},

--- a/release/release-please-manifest.prerelease.json
+++ b/release/release-please-manifest.prerelease.json
@@ -1,11 +1,11 @@
 {
-	"packages/cli-core": "0.0.1-next.49",
-	"packages/core": "0.0.1-next.49",
-	"packages/crypto": "0.0.1-next.49",
-	"packages/entity": "0.0.1-next.49",
-	"packages/image": "0.0.1-next.49",
-	"packages/modules": "0.0.1-next.49",
-	"packages/qr": "0.0.1-next.49",
-	"packages/web": "0.0.1-next.49",
-	"apps/crypto-cli": "0.0.1-next.49"
+	"packages/cli-core": "0.0.1-next.50",
+	"packages/core": "0.0.1-next.50",
+	"packages/crypto": "0.0.1-next.50",
+	"packages/entity": "0.0.1-next.50",
+	"packages/image": "0.0.1-next.50",
+	"packages/modules": "0.0.1-next.50",
+	"packages/qr": "0.0.1-next.50",
+	"packages/web": "0.0.1-next.50",
+	"apps/crypto-cli": "0.0.1-next.50"
 }


### PR DESCRIPTION
chore: :robot: prerelease release prepared
---


<details><summary>cli-core: 0.0.1-next.50</summary>

## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/cli-core-v0.0.1-next.49...cli-core-v0.0.1-next.50) (2025-03-25)


### Miscellaneous Chores

* **cli-core:** Synchronize repo versions


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
    * @twin.org/crypto bumped from 0.0.1-next.49 to 0.0.1-next.50
</details>

<details><summary>core: 0.0.1-next.50</summary>

## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/core-v0.0.1-next.49...core-v0.0.1-next.50) (2025-03-25)


### Miscellaneous Chores

* **core:** Synchronize repo versions
</details>

<details><summary>crypto: 0.0.1-next.50</summary>

## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/crypto-v0.0.1-next.49...crypto-v0.0.1-next.50) (2025-03-25)


### Miscellaneous Chores

* **crypto:** Synchronize repo versions


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
</details>

<details><summary>crypto-cli: 0.0.1-next.50</summary>

## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/crypto-cli-v0.0.1-next.49...crypto-cli-v0.0.1-next.50) (2025-03-25)


### Features

* add version type ([ae50cd9](https://github.com/twinfoundation/framework/commit/ae50cd99d342ed8eeb55290a52e9fed80a2af99e))
* remove version type ([553aa55](https://github.com/twinfoundation/framework/commit/553aa55bd79b8f930155035e522af2b0f6e3d0c8))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/cli-core bumped from 0.0.1-next.49 to 0.0.1-next.50
    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
    * @twin.org/crypto bumped from 0.0.1-next.49 to 0.0.1-next.50
</details>

<details><summary>entity: 0.0.1-next.50</summary>

## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/entity-v0.0.1-next.49...entity-v0.0.1-next.50) (2025-03-25)


### Miscellaneous Chores

* **entity:** Synchronize repo versions


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
</details>

<details><summary>image: 0.0.1-next.50</summary>

## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/image-v0.0.1-next.49...image-v0.0.1-next.50) (2025-03-25)


### Miscellaneous Chores

* **image:** Synchronize repo versions


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
</details>

<details><summary>modules: 0.0.1-next.50</summary>

## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/modules-v0.0.1-next.49...modules-v0.0.1-next.50) (2025-03-25)


### Miscellaneous Chores

* **modules:** Synchronize repo versions


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/core bumped from next to 0.0.1-next.50
</details>

<details><summary>qr: 0.0.1-next.50</summary>

## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/qr-v0.0.1-next.49...qr-v0.0.1-next.50) (2025-03-25)


### Miscellaneous Chores

* **qr:** Synchronize repo versions


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
    * @twin.org/image bumped from 0.0.1-next.49 to 0.0.1-next.50
</details>

<details><summary>web: 0.0.1-next.50</summary>

## [0.0.1-next.50](https://github.com/twinfoundation/framework/compare/web-v0.0.1-next.49...web-v0.0.1-next.50) (2025-03-25)


### Miscellaneous Chores

* **web:** Synchronize repo versions


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @twin.org/core bumped from 0.0.1-next.49 to 0.0.1-next.50
    * @twin.org/crypto bumped from 0.0.1-next.49 to 0.0.1-next.50
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).